### PR TITLE
Escape string literal in validation error messages, as the output reg…

### DIFF
--- a/SimpleSwaggerGenerator/AutoRest/core/Utilities/Extensions.cs
+++ b/SimpleSwaggerGenerator/AutoRest/core/Utilities/Extensions.cs
@@ -369,6 +369,25 @@ namespace AutoRest.Core.Utilities
         public static string EscapeXmlComment(this Fixable<string> comment) => EscapeXmlComment(comment.Value);
 
         /// <summary>
+        /// Escape reserved characters in C# string literals with their escaped representations
+        /// </summary>
+        /// <param name="str">The string to escape</param>
+        /// <returns>The text appropriately escaped</returns>
+        public static string EscapeStringLiteral(this string str)
+        {
+            if (str == null)
+            {
+                return null;
+            }
+
+            return new StringBuilder(str)
+                .Replace("\\", "\\\\")
+                .Replace("\"", "\\\"").ToString();
+        }
+
+        public static string EscapeStringLiteral(this Fixable<string> str) => EscapeStringLiteral(str.Value);
+
+        /// <summary>
         /// Returns true if the type is a PrimaryType with KnownPrimaryType matching typeToMatch.
         /// </summary>
         /// <param name="type"></param>

--- a/SimpleSwaggerGenerator/AutoRest/generator/ClientModelExtensions.cs
+++ b/SimpleSwaggerGenerator/AutoRest/generator/ClientModelExtensions.cs
@@ -456,7 +456,7 @@ namespace AutoRest.CSharp
                         sb.AppendLine("if ({0})", constraintCheck)
                             .AppendLine("{").Indent()
                           .AppendLine("throw new System.Exception(\"Validation Failed: {0}, '{1}', {2}\");",
-                                constraint, valueReference.Replace("this.", ""), constraintValue).Outdent()
+                                constraint, valueReference.Replace("this.", ""), constraintValue.EscapeStringLiteral()).Outdent()
                             .AppendLine("}");
                     }
                     else


### PR DESCRIPTION
…ular expression strings have " and \ characters in them